### PR TITLE
Fix NullPointerException: taintedCommand[3] == null error

### DIFF
--- a/src/za/jamie/androidffmpegcmdline/ffmpeg/FfmpegJob.java
+++ b/src/za/jamie/androidffmpegcmdline/ffmpeg/FfmpegJob.java
@@ -55,15 +55,15 @@ public class FfmpegJob {
 		cmd.add(mFfmpegPath);
 		cmd.add("-y");
 		
-		if (TextUtils.isEmpty(inputFormat)) {
+		if (!TextUtils.isEmpty(inputFormat)) {
 			cmd.add(FFMPEGArg.ARG_FORMAT);
 			cmd.add(inputFormat);
 		}
-		if (TextUtils.isEmpty(inputVideoCodec)) {
+		if (!TextUtils.isEmpty(inputVideoCodec)) {
 			cmd.add(FFMPEGArg.ARG_VIDEOCODEC);
 			cmd.add(inputVideoCodec);
 		}
-		if (TextUtils.isEmpty(inputAudioCodec)) {
+		if (!TextUtils.isEmpty(inputAudioCodec)) {
 			cmd.add(FFMPEGArg.ARG_AUDIOCODEC);
 			cmd.add(inputAudioCodec);
 		}
@@ -86,15 +86,15 @@ public class FfmpegJob {
 				cmd.add(FFMPEGArg.ARG_FRAMERATE);
 				cmd.add(String.valueOf(videoFramerate));
 			}
-			if (TextUtils.isEmpty(videoCodec)) {
+			if (!TextUtils.isEmpty(videoCodec)) {
 				cmd.add(FFMPEGArg.ARG_VIDEOCODEC);
 				cmd.add(videoCodec);
 			}
-			if (TextUtils.isEmpty(videoBitStreamFilter)) {
+			if (!TextUtils.isEmpty(videoBitStreamFilter)) {
 				cmd.add(FFMPEGArg.ARG_VIDEOBITSTREAMFILTER);
 				cmd.add(videoBitStreamFilter);
 			}		
-			if (TextUtils.isEmpty(videoFilter)) {
+			if (!TextUtils.isEmpty(videoFilter)) {
 				cmd.add(FFMPEGArg.ARG_VIDEOFILTER);
 				cmd.add(videoFilter);
 			}
@@ -102,15 +102,15 @@ public class FfmpegJob {
 		if (disableAudio) {
 			cmd.add(FFMPEGArg.ARG_DISABLE_AUDIO);
 		} else {
-			if (TextUtils.isEmpty(audioCodec)) {
+			if (!TextUtils.isEmpty(audioCodec)) {
 				cmd.add(FFMPEGArg.ARG_AUDIOCODEC);
 				cmd.add(audioCodec);
 			}
-			if (TextUtils.isEmpty(audioBitStreamFilter)) {
+			if (!TextUtils.isEmpty(audioBitStreamFilter)) {
 				cmd.add(FFMPEGArg.ARG_AUDIOBITSTREAMFILTER);
 				cmd.add(audioBitStreamFilter);
 			}
-			if (TextUtils.isEmpty(audioFilter)) {
+			if (!TextUtils.isEmpty(audioFilter)) {
 				cmd.add(FFMPEGArg.ARG_AUDIOFILTER);
 				cmd.add(audioFilter);
 			}
@@ -128,7 +128,7 @@ public class FfmpegJob {
 			}
 		}
 			
-		if (TextUtils.isEmpty(format)) {
+		if (!TextUtils.isEmpty(format)) {
 			cmd.add("-f");
 			cmd.add(format);
 		}


### PR DESCRIPTION
This fixes an issue with a NullPointerException being thrown:

``` java
E/AndroidRuntime(13759): java.lang.RuntimeException: An error occured while executing doInBackground()
E/AndroidRuntime(13759):    at android.os.AsyncTask$3.done(AsyncTask.java:300)
E/AndroidRuntime(13759):    at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:355)
E/AndroidRuntime(13759):    at java.util.concurrent.FutureTask.setException(FutureTask.java:222)
E/AndroidRuntime(13759):    at java.util.concurrent.FutureTask.run(FutureTask.java:242)
E/AndroidRuntime(13759):    at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:231)
E/AndroidRuntime(13759):    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
E/AndroidRuntime(13759):    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
E/AndroidRuntime(13759):    at java.lang.Thread.run(Thread.java:841)
E/AndroidRuntime(13759): Caused by: java.lang.NullPointerException: taintedCommand[3] == null
E/AndroidRuntime(13759):    at java.lang.ProcessManager.exec(ProcessManager.java:184)
E/AndroidRuntime(13759):    at java.lang.ProcessBuilder.start(ProcessBuilder.java:195)
E/AndroidRuntime(13759):    at za.jamie.androidffmpegcmdline.ffmpeg.ProcessRunnable.run(ProcessRunnable.java:24)
E/AndroidRuntime(13759):    at za.jamie.androidffmpegcmdline.MainActivity$3.doInBackground(MainActivity.java:154)
E/AndroidRuntime(13759):    at za.jamie.androidffmpegcmdline.MainActivity$3.doInBackground(MainActivity.java:1)
E/AndroidRuntime(13759):    at android.os.AsyncTask$2.call(AsyncTask.java:288)
E/AndroidRuntime(13759):    at java.util.concurrent.FutureTask.run(FutureTask.java:237)
E/AndroidRuntime(13759):    ... 4 more
```

It looks like some of the logic for detecting blank fields was backwards, not using the value of a field unless that field was empty.
